### PR TITLE
More minor fixes

### DIFF
--- a/gui_source/guimainwindow.cpp
+++ b/gui_source/guimainwindow.cpp
@@ -277,7 +277,7 @@ void GuiMainWindow::on_actionCPP_triggered()
         pdbData.handleOptions.bFixTypes=false;
         pdbData.handleOptions.bShowComments=false;
         pdbData.handleOptions.fixOffsets=QWinPDB::FO_NO;
-        pdbData.handleOptions.sortType=QWinPDB::ST_ID;
+        pdbData.handleOptions.sortType=QWinPDB::ST_DEP;
         pdbData.handleOptions.exportType=QWinPDB::ET_CPLUSPLUS;
 
         DialogExport dialogExport(this,&pdbData);

--- a/qwinpdb.cpp
+++ b/qwinpdb.cpp
@@ -2077,7 +2077,7 @@ QList<QWinPDB::ELEM> QWinPDB::_fixBitFields(QList<QWinPDB::ELEM> *pListChildren)
 
             if(nSize==3) // TODO !!!
             {
-                if((pListChildren->at(i+1).dwSize==1)&&(pListChildren->at(i+1).dwOffset==(nOffset+nSize)))
+                if((i+1<pListChildren->size())&&(pListChildren->at(i+1).dwSize==1)&&(pListChildren->at(i+1).dwOffset==(nOffset+nSize)))
                 {
                     i++;
                     listBitFields.append(pListChildren->at(i));

--- a/qwinpdb.cpp
+++ b/qwinpdb.cpp
@@ -93,11 +93,11 @@ bool QWinPDB::loadFromFile(QString sFileName)
 
     // TODO msdia option
 
-    HRESULT hr=NoRegCoCreate(L"msdia140.dll", _uuidof(DiaSourceAlt),
+    HRESULT hr=NoRegCoCreate(L"msdia140.dll", _uuidof(DiaSource),
                               _uuidof(IDiaDataSource),
                               (void **)(&g_pDiaDataSource));
 
-//    HRESULT hr=NoRegCoCreate(L"msdia120.dll", _uuidof(DiaSourceAlt),
+//    HRESULT hr=NoRegCoCreate(L"msdia120.dll", _uuidof(DiaSource),
 //                              _uuidof(IDiaDataSource),
 //                              (void **)(&pDiaDataSource));
 

--- a/qwinpdb.cpp
+++ b/qwinpdb.cpp
@@ -1403,6 +1403,12 @@ QString QWinPDB::getName(IDiaSymbol *pSymbol)
         pSymbol->get_symIndexId(&dwSymIndex);
         sResult=sResult.replace("<unnamed-tag>",QString("_unnamed_%1").arg(dwSymIndex));
     }
+    else if(sResult.contains("<anonymous-tag>"))
+    {
+        DWORD dwSymIndex=0;
+        pSymbol->get_symIndexId(&dwSymIndex);
+        sResult=sResult.replace("<anonymous-tag>",QString("_anonymous_%1").arg(dwSymIndex));
+    }
 
     return sResult;
 }


### PR DESCRIPTION
Dumping `ntoskrnl.exe` PDB doesn't crash with all options doesn't crash anymore

```cpp
struct _MMSECTION_FLAGS2
{
    unsigned int PartitionId:10;
    unsigned int NoCrossPartitionAccess:1;
    unsigned int SubsectionCrossPartitionReferenceOverflow:1;
};
```

This was crashing because of out of bounds, it says TODO there and the output with 'Fix offsets' (whatever that means) now is:

```cpp
struct _MMSECTION_FLAGS2// Size=0x4
{
    struct // Size=0x3
    {
        unsigned short PartitionId:10;// Offset=0x0 Size=0x2 BitOffset=0x0 BitSize=0xa
        unsigned char NoCrossPartitionAccess:1;// Offset=0x2 Size=0x1 BitOffset=0x0 BitSize=0x1
        unsigned char SubsectionCrossPartitionReferenceOverflow:1;// Offset=0x2 Size=0x1 BitOffset=0x1 BitSize=0x1
    };
};
```

Seems wrong, but at least it doesn't crash 🤷🏻 